### PR TITLE
Find games that are not in the main Steam library

### DIFF
--- a/main.py
+++ b/main.py
@@ -595,6 +595,34 @@ def _find_in_libraries(*parts: str) -> str:
     return ""
 
 
+def _proton_builds() -> list:
+    """Every installed Proton build, by name, from every Steam library.
+
+    Steam installs a Proton into whichever library it was pointed at, and a
+    Deck whose games are on the card usually has its Protons there too. This
+    listed the main library only, so a card-based setup was told it had no
+    usable Proton and every me3 game refused to launch - the same assumption
+    that made Witcher 3 on a microSD report "game not found", in a different
+    corner of the file.
+
+    Names, not paths: the caller offers them as a choice and matches on the
+    version prefix. A build present in two libraries is one choice.
+    """
+    names = set()
+    for lib in _steam_libraries():
+        common = os.path.join(lib, "common")
+        try:
+            entries = os.listdir(common)
+        except OSError:
+            continue
+        for name in entries:
+            if name.lower().startswith("proton") and os.path.isdir(
+                os.path.join(common, name)
+            ):
+                names.add(name)
+    return sorted(names)
+
+
 def _game_paths(install_dir: str, mods_subdir: str):
     install_path = _find_in_libraries("common", install_dir) or os.path.join(
         STEAM_COMMON, install_dir
@@ -15799,14 +15827,7 @@ query Link($slug: String!, $domainName: String!) {
         what the generated profile currently activates."""
         status = await self.get_me3_status()
         install_path = _game_paths(install_dir, "")[0]
-        protons = []
-        if os.path.isdir(STEAM_COMMON):
-            protons = sorted(
-                name
-                for name in os.listdir(STEAM_COMMON)
-                if name.lower().startswith("proton")
-                and os.path.isdir(os.path.join(STEAM_COMMON, name))
-            )
+        protons = _proton_builds()
         settings = _load_settings()
         records = _me3_records(settings, game_domain)
         profile = _me3_profile_path(game_domain)

--- a/main.py
+++ b/main.py
@@ -409,7 +409,7 @@ _GAME_VERSION_READERS = {
 
 def _bl_installed_game_version() -> str:
     """Bannerlord's version, from Native/SubModule.xml. "" when unknown."""
-    install_path = _game_paths("Mount & Blade II Bannerlord", "Modules")[0]
+    install_path = _game_dir("Mount & Blade II Bannerlord")
     manifest = os.path.join(
         install_path, "Modules", "Native", "SubModule.xml"
     )
@@ -623,10 +623,30 @@ def _proton_builds() -> list:
     return sorted(names)
 
 
-def _game_paths(install_dir: str, mods_subdir: str):
-    install_path = _find_in_libraries("common", install_dir) or os.path.join(
+def _game_dir(install_dir: str) -> str:
+    """The game's own folder, from whichever library holds it.
+
+    The main library is the fallback here, not the assumption anywhere
+    else: this is the one place allowed to name STEAM_COMMON for a game.
+    """
+    return _find_in_libraries("common", install_dir) or os.path.join(
         STEAM_COMMON, install_dir
     )
+
+
+def _mods_dir(install_dir: str, mods_subdir: str) -> str:
+    """The game's mods folder, from whichever library holds the game."""
+    return os.path.join(_game_dir(install_dir), mods_subdir)
+
+
+def _game_paths(install_dir: str, mods_subdir: str):
+    """Game folder, mods folder, and the disabled-mods folder beside it.
+
+    Callers that only want the game folder ask _game_dir for it - indexing
+    a tuple to reach past two values you did not ask for is how a caller
+    ends up depending on the shape of an answer instead of the answer.
+    """
+    install_path = _game_dir(install_dir)
     mods_path = os.path.join(install_path, mods_subdir)
     disabled_path = os.path.join(install_path, f"{mods_subdir}-disabled")
     return install_path, mods_path, disabled_path
@@ -12653,7 +12673,7 @@ query Link($slug: String!, $domainName: String!) {
                 try:
                     stripped = _bl_strip_outdated_shader_caches(
                         game_domain,
-                        _game_paths(install_dir, mods_subdir)[0],
+                        _game_dir(install_dir),
                         int(app_id or 0),
                     )
                 except Exception as e:  # noqa: BLE001 - never fail an install
@@ -15319,7 +15339,7 @@ query Link($slug: String!, $domainName: String!) {
         dst = _game_prefs_path(app_id, prefs_subpath)
         if os.path.isfile(dst):
             return {"ok": True, "seeded": False}
-        src = os.path.join(_game_paths(install_dir, "")[0], *source_rel.split("/"))
+        src = os.path.join(_game_dir(install_dir), *source_rel.split("/"))
         if not os.path.isfile(src):
             return {"ok": False, "error": f"{source_rel} not found in game dir"}
         _makedirs_for(dst)
@@ -15373,7 +15393,7 @@ query Link($slug: String!, $domainName: String!) {
         api_key = _load_settings().get("api_key")
         if not api_key:
             return _fail("auth", "Not signed in")
-        install_path = _game_paths(install_dir, "")[0]
+        install_path = _game_dir(install_dir)
         if not os.path.isdir(install_path):
             return _fail("game", "Game install folder not found")
         proton, compat, steam_root, perr = _proton_binary_for(app_id)
@@ -15826,7 +15846,7 @@ query Link($slug: String!, $domainName: String!) {
         me3 copy is there, whether a Proton it can use is installed, and
         what the generated profile currently activates."""
         status = await self.get_me3_status()
-        install_path = _game_paths(install_dir, "")[0]
+        install_path = _game_dir(install_dir)
         protons = _proton_builds()
         settings = _load_settings()
         records = _me3_records(settings, game_domain)
@@ -16030,7 +16050,7 @@ query Link($slug: String!, $domainName: String!) {
             api_key = _load_settings().get("api_key")
             if not api_key:
                 return {"ok": False, "error": "Not signed in"}
-            install_path = _game_paths(install_dir, "")[0]
+            install_path = _game_dir(install_dir)
             if not os.path.isdir(install_path):
                 return {"ok": False, "error": "Game install folder not found"}
 
@@ -16285,7 +16305,7 @@ query Link($slug: String!, $domainName: String!) {
         ('X.esm is missing required files') - the #1 "game won't start"
         cause after a collection that assumes DLC or external
         prerequisites (e.g. TTW). Returns [{plugin, missing:[...]}]."""
-        data_dir = _game_paths(install_dir, mods_subdir)[1]
+        data_dir = _mods_dir(install_dir, mods_subdir)
         if not os.path.isdir(data_dir):
             return {"ok": False, "error": "Game data folder not found"}
         if not plugins_subpath:
@@ -16333,7 +16353,7 @@ query Link($slug: String!, $domainName: String!) {
             return {"ok": True, "available": False}
         log_path = _game_prefs_path(app_id, log_subpath)
         plugins_dir = os.path.join(
-            _game_paths(install_dir, "")[0], *SE_PLUGIN_DIRS.get(
+            _game_dir(install_dir), *SE_PLUGIN_DIRS.get(
                 log_subpath.split("/")[0], ("Data", "SKSE", "Plugins")
             )
         )
@@ -16417,7 +16437,7 @@ query Link($slug: String!, $domainName: String!) {
         is never deleted - the extender only scans *.dll, so a suffix is
         enough to take it out of the game, and the user can always have
         it back."""
-        base = os.path.abspath(_game_paths(install_dir, "")[0])
+        base = os.path.abspath(_game_dir(install_dir))
         target_dir = os.path.abspath(plugins_dir or "")
         # The directory comes from the frontend; never touch anything
         # outside the game it names.
@@ -16480,7 +16500,7 @@ query Link($slug: String!, $domainName: String!) {
         hook."""
         if not _safe_rel_path(rel_path or ""):
             return {"ok": False, "error": "Invalid path"}
-        path = os.path.join(_game_paths(install_dir, "")[0], *rel_path.split("/"))
+        path = os.path.join(_game_dir(install_dir), *rel_path.split("/"))
         return {"ok": True, "exists": os.path.exists(path)}
 
     async def get_show_adult(self) -> dict:
@@ -17693,7 +17713,7 @@ query Link($slug: String!, $domainName: String!) {
             return {"ok": True, "supported": False}
         timestamp_ordered = plugins_style == "listed"
         path = _plugins_txt_path(app_id, plugins_subpath)
-        data_path = os.path.join(_game_paths(install_dir, "")[0], "Data")
+        data_path = os.path.join(_game_dir(install_dir), "Data")
         if not os.path.isfile(path) or not os.path.isdir(data_path):
             return {"ok": True, "supported": False}
         implicit = IMPLICIT_MASTERS_BY_DOMAIN.get(game_domain, frozenset())
@@ -18396,7 +18416,7 @@ query CollectionInstructions($slug: String!) {
             if install_dir:
                 runtime = await asyncio.to_thread(
                     _script_extender_runtime,
-                    _game_paths(install_dir, "")[0],
+                    _game_dir(install_dir),
                 )
                 detail = await self.get_collection(slug, game_domain)
                 target = _address_library_target(
@@ -18968,7 +18988,7 @@ query CollectionInstructions($slug: String!) {
             if rec.get("mod_id") and rec.get("enabled") is not False
         }
         install_path, _mods_path, _dis = _game_paths(install_dir, mods_subdir)
-        data_path = _game_paths(install_dir, mods_subdir)[1]
+        data_path = _mods_dir(install_dir, mods_subdir)
         build = _steam_build_id(app_id)
         # Asked of every record, not just the enabled ones: a failing script
         # belonging to a mod already switched off is exactly what we must
@@ -19048,7 +19068,7 @@ query CollectionInstructions($slug: String!) {
             # dependency and may still be repairable, so those are
             # reported and left alone.
             se_dir = os.path.join(
-                _game_paths(install_dir, "")[0], *SE_PLUGIN_DIRS.get(
+                _game_dir(install_dir), *SE_PLUGIN_DIRS.get(
                     se_log_subpath.split("/")[0], ("Data", "SKSE", "Plugins")
                 )
             )
@@ -19840,7 +19860,7 @@ query CollectionInstructions($slug: String!) {
         if not table:
             return {"ok": True, "supported": True, "bad": [], "extra": 0}
         path = _plugins_txt_path(app_id, plugins_subpath)
-        data_path = os.path.join(_game_paths(install_dir, "")[0], "Data")
+        data_path = os.path.join(_game_dir(install_dir), "Data")
         entries = _plugin_entries(_read_plugins_txt(path), plugins_style)
         listed = [n for n, _ in entries]
         on = {n.lower() for n, enabled in entries if enabled}
@@ -19866,7 +19886,7 @@ query CollectionInstructions($slug: String!) {
             return {"ok": False, "error": "This game has no plugin list"}
         table = KNOWN_BAD_PLUGINS.get(game_domain) or {}
         path = _plugins_txt_path(app_id, plugins_subpath)
-        data_path = os.path.join(_game_paths(install_dir, "")[0], "Data")
+        data_path = os.path.join(_game_dir(install_dir), "Data")
         lines = _read_plugins_txt(path)
         header = [l for l in lines if l.strip().startswith("#")]
         entries = _plugin_entries(lines, plugins_style)
@@ -19927,7 +19947,7 @@ query CollectionInstructions($slug: String!) {
         path = _plugins_txt_path(app_id, plugins_subpath)
         if not os.path.isfile(path):
             return {"ok": True, "changed": 0}
-        data_path = os.path.join(_game_paths(install_dir, "")[0], "Data")
+        data_path = os.path.join(_game_dir(install_dir), "Data")
         skips = _load_skips(game_domain)
         if not skips:
             return {"ok": True, "changed": 0}
@@ -19975,7 +19995,7 @@ query CollectionInstructions($slug: String!) {
         if not plugins_subpath:
             return {"ok": False, "error": "This game has no plugin list"}
         path = _plugins_txt_path(app_id, plugins_subpath)
-        data_path = os.path.join(_game_paths(install_dir, "")[0], "Data")
+        data_path = os.path.join(_game_dir(install_dir), "Data")
         r = _rewrite_load_order(
             data_path, path, plugins_style,
             IMPLICIT_MASTERS_BY_DOMAIN.get(game_domain, frozenset()),
@@ -20078,7 +20098,7 @@ query CollectionInstructions($slug: String!) {
         # instead of politely declining to learn from it.
         parked = []
         se_dir = os.path.join(
-            _game_paths(install_dir, "")[0],
+            _game_dir(install_dir),
             *SE_PLUGIN_DIRS.get(log_subpath.split("/")[0],
                                 ("Data", "SKSE", "Plugins"))
         )
@@ -20144,7 +20164,7 @@ query CollectionInstructions($slug: String!) {
         # skipping this is how a "clean" test ends up crashing on missing
         # content instead of on the thing being tested.
         data_path = os.path.join(
-            _game_paths(state["install_dir"], "")[0], "Data"
+            _game_dir(state["install_dir"]), "Data"
         )
         _rewrite_load_order(
             data_path, path, state["plugins_style"],
@@ -20168,7 +20188,7 @@ query CollectionInstructions($slug: String!) {
         collateral = []
         if state.get("found"):
             data_path = os.path.join(
-            _game_paths(state["install_dir"], "")[0], "Data"
+            _game_dir(state["install_dir"]), "Data"
         )
             collateral = await asyncio.to_thread(
                 _dependents_closure, data_path, state["order"],
@@ -20205,7 +20225,7 @@ query CollectionInstructions($slug: String!) {
             ("*" + n if n.lower() in on else n) for n, _ in entries
         ])
         data_path = os.path.join(
-            _game_paths(state["install_dir"], "")[0], "Data"
+            _game_dir(state["install_dir"]), "Data"
         )
         _rewrite_load_order(
             data_path, path, state["plugins_style"],
@@ -20587,7 +20607,7 @@ query CollectionInstructions($slug: String!) {
         scan(disabled_path, False)
         # Mods routed to alternate targets (UE4SS dirs, LogicMods) don't
         # live in the scanned dirs - list them from their records.
-        install_path = _game_paths(install_dir, "")[0]
+        install_path = _game_dir(install_dir)
         for key, rec in records.items():
             target = rec.get("target")
             if not target:
@@ -20851,7 +20871,7 @@ query CollectionInstructions($slug: String!) {
             settings = _load_settings()
             records = settings.get("installed", {}).get(game_domain, {})
             rec = records.get(folder) or rec
-            install_path = _game_paths(install_dir, "")[0]
+            install_path = _game_dir(install_dir)
             park = _parked_files_dir(game_domain, folder)
             shared = _shared_paths(records, folder, modes=("files",))
             movable = [
@@ -20880,7 +20900,7 @@ query CollectionInstructions($slug: String!) {
             )
             return {"ok": True, "moved": moved, "shared": len(shared)}
         if rec and rec.get("target"):
-            install_path = _game_paths(install_dir, "")[0]
+            install_path = _game_dir(install_dir)
             base = os.path.join(install_path, *rec["target"].split("/"))
             real = rec.get("folder") or folder
             if rec["target"] == "dlc" and _w3_official_dlc(real):
@@ -21100,7 +21120,7 @@ query CollectionInstructions($slug: String!) {
         settings = _load_settings()
         rec = settings.get("installed", {}).get(game_domain, {}).get(folder)
         if rec and rec.get("target"):
-            install_path = _game_paths(install_dir, "")[0]
+            install_path = _game_dir(install_dir)
             base = os.path.join(install_path, *rec["target"].split("/"))
             if rec.get("mode") == "files":
                 for name in rec.get("files") or []:
@@ -21152,12 +21172,12 @@ query CollectionInstructions($slug: String!) {
         # A merge participant leaving: recompute its merged scripts from
         # the remaining participants.
         _w3_unmerge(
-            game_domain, _game_paths(install_dir, "")[0],
+            game_domain, _game_dir(install_dir),
             mods_path, folder, settings,
         )
         _save_settings(settings)
         if dropped:
-            install_root = _game_paths(install_dir, "")[0]
+            install_root = _game_dir(install_dir)
             _w3_remove_menu_xmls(install_root, dropped)
             pc_dir = os.path.join(install_root, *W3_MENU_DIR.split("/"))
             if os.path.isdir(pc_dir):

--- a/main.py
+++ b/main.py
@@ -15291,7 +15291,7 @@ query Link($slug: String!, $domainName: String!) {
         dst = _game_prefs_path(app_id, prefs_subpath)
         if os.path.isfile(dst):
             return {"ok": True, "seeded": False}
-        src = os.path.join(STEAM_COMMON, install_dir, *source_rel.split("/"))
+        src = os.path.join(_game_paths(install_dir, "")[0], *source_rel.split("/"))
         if not os.path.isfile(src):
             return {"ok": False, "error": f"{source_rel} not found in game dir"}
         _makedirs_for(dst)
@@ -15345,7 +15345,7 @@ query Link($slug: String!, $domainName: String!) {
         api_key = _load_settings().get("api_key")
         if not api_key:
             return _fail("auth", "Not signed in")
-        install_path = os.path.join(STEAM_COMMON, install_dir)
+        install_path = _game_paths(install_dir, "")[0]
         if not os.path.isdir(install_path):
             return _fail("game", "Game install folder not found")
         proton, compat, steam_root, perr = _proton_binary_for(app_id)
@@ -15798,7 +15798,7 @@ query Link($slug: String!, $domainName: String!) {
         me3 copy is there, whether a Proton it can use is installed, and
         what the generated profile currently activates."""
         status = await self.get_me3_status()
-        install_path = os.path.join(STEAM_COMMON, install_dir)
+        install_path = _game_paths(install_dir, "")[0]
         protons = []
         if os.path.isdir(STEAM_COMMON):
             protons = sorted(
@@ -16009,7 +16009,7 @@ query Link($slug: String!, $domainName: String!) {
             api_key = _load_settings().get("api_key")
             if not api_key:
                 return {"ok": False, "error": "Not signed in"}
-            install_path = os.path.join(STEAM_COMMON, install_dir)
+            install_path = _game_paths(install_dir, "")[0]
             if not os.path.isdir(install_path):
                 return {"ok": False, "error": "Game install folder not found"}
 
@@ -16264,7 +16264,7 @@ query Link($slug: String!, $domainName: String!) {
         ('X.esm is missing required files') - the #1 "game won't start"
         cause after a collection that assumes DLC or external
         prerequisites (e.g. TTW). Returns [{plugin, missing:[...]}]."""
-        data_dir = os.path.join(STEAM_COMMON, install_dir, mods_subdir)
+        data_dir = _game_paths(install_dir, mods_subdir)[1]
         if not os.path.isdir(data_dir):
             return {"ok": False, "error": "Game data folder not found"}
         if not plugins_subpath:
@@ -16312,7 +16312,7 @@ query Link($slug: String!, $domainName: String!) {
             return {"ok": True, "available": False}
         log_path = _game_prefs_path(app_id, log_subpath)
         plugins_dir = os.path.join(
-            STEAM_COMMON, install_dir, *SE_PLUGIN_DIRS.get(
+            _game_paths(install_dir, "")[0], *SE_PLUGIN_DIRS.get(
                 log_subpath.split("/")[0], ("Data", "SKSE", "Plugins")
             )
         )
@@ -16396,7 +16396,7 @@ query Link($slug: String!, $domainName: String!) {
         is never deleted - the extender only scans *.dll, so a suffix is
         enough to take it out of the game, and the user can always have
         it back."""
-        base = os.path.abspath(os.path.join(STEAM_COMMON, install_dir))
+        base = os.path.abspath(_game_paths(install_dir, "")[0])
         target_dir = os.path.abspath(plugins_dir or "")
         # The directory comes from the frontend; never touch anything
         # outside the game it names.
@@ -16459,7 +16459,7 @@ query Link($slug: String!, $domainName: String!) {
         hook."""
         if not _safe_rel_path(rel_path or ""):
             return {"ok": False, "error": "Invalid path"}
-        path = os.path.join(STEAM_COMMON, install_dir, *rel_path.split("/"))
+        path = os.path.join(_game_paths(install_dir, "")[0], *rel_path.split("/"))
         return {"ok": True, "exists": os.path.exists(path)}
 
     async def get_show_adult(self) -> dict:
@@ -17672,7 +17672,7 @@ query Link($slug: String!, $domainName: String!) {
             return {"ok": True, "supported": False}
         timestamp_ordered = plugins_style == "listed"
         path = _plugins_txt_path(app_id, plugins_subpath)
-        data_path = os.path.join(STEAM_COMMON, install_dir, "Data")
+        data_path = os.path.join(_game_paths(install_dir, "")[0], "Data")
         if not os.path.isfile(path) or not os.path.isdir(data_path):
             return {"ok": True, "supported": False}
         implicit = IMPLICIT_MASTERS_BY_DOMAIN.get(game_domain, frozenset())
@@ -18375,7 +18375,7 @@ query CollectionInstructions($slug: String!) {
             if install_dir:
                 runtime = await asyncio.to_thread(
                     _script_extender_runtime,
-                    os.path.join(STEAM_COMMON, install_dir),
+                    _game_paths(install_dir, "")[0],
                 )
                 detail = await self.get_collection(slug, game_domain)
                 target = _address_library_target(
@@ -19027,7 +19027,7 @@ query CollectionInstructions($slug: String!) {
             # dependency and may still be repairable, so those are
             # reported and left alone.
             se_dir = os.path.join(
-                STEAM_COMMON, install_dir, *SE_PLUGIN_DIRS.get(
+                _game_paths(install_dir, "")[0], *SE_PLUGIN_DIRS.get(
                     se_log_subpath.split("/")[0], ("Data", "SKSE", "Plugins")
                 )
             )
@@ -19819,7 +19819,7 @@ query CollectionInstructions($slug: String!) {
         if not table:
             return {"ok": True, "supported": True, "bad": [], "extra": 0}
         path = _plugins_txt_path(app_id, plugins_subpath)
-        data_path = os.path.join(STEAM_COMMON, install_dir, "Data")
+        data_path = os.path.join(_game_paths(install_dir, "")[0], "Data")
         entries = _plugin_entries(_read_plugins_txt(path), plugins_style)
         listed = [n for n, _ in entries]
         on = {n.lower() for n, enabled in entries if enabled}
@@ -19845,7 +19845,7 @@ query CollectionInstructions($slug: String!) {
             return {"ok": False, "error": "This game has no plugin list"}
         table = KNOWN_BAD_PLUGINS.get(game_domain) or {}
         path = _plugins_txt_path(app_id, plugins_subpath)
-        data_path = os.path.join(STEAM_COMMON, install_dir, "Data")
+        data_path = os.path.join(_game_paths(install_dir, "")[0], "Data")
         lines = _read_plugins_txt(path)
         header = [l for l in lines if l.strip().startswith("#")]
         entries = _plugin_entries(lines, plugins_style)
@@ -19906,7 +19906,7 @@ query CollectionInstructions($slug: String!) {
         path = _plugins_txt_path(app_id, plugins_subpath)
         if not os.path.isfile(path):
             return {"ok": True, "changed": 0}
-        data_path = os.path.join(STEAM_COMMON, install_dir, "Data")
+        data_path = os.path.join(_game_paths(install_dir, "")[0], "Data")
         skips = _load_skips(game_domain)
         if not skips:
             return {"ok": True, "changed": 0}
@@ -19954,7 +19954,7 @@ query CollectionInstructions($slug: String!) {
         if not plugins_subpath:
             return {"ok": False, "error": "This game has no plugin list"}
         path = _plugins_txt_path(app_id, plugins_subpath)
-        data_path = os.path.join(STEAM_COMMON, install_dir, "Data")
+        data_path = os.path.join(_game_paths(install_dir, "")[0], "Data")
         r = _rewrite_load_order(
             data_path, path, plugins_style,
             IMPLICIT_MASTERS_BY_DOMAIN.get(game_domain, frozenset()),
@@ -20057,7 +20057,7 @@ query CollectionInstructions($slug: String!) {
         # instead of politely declining to learn from it.
         parked = []
         se_dir = os.path.join(
-            STEAM_COMMON, install_dir,
+            _game_paths(install_dir, "")[0],
             *SE_PLUGIN_DIRS.get(log_subpath.split("/")[0],
                                 ("Data", "SKSE", "Plugins"))
         )
@@ -20122,7 +20122,9 @@ query CollectionInstructions($slug: String!) {
         # Pull in the masters the prefix needs and put it in load order -
         # skipping this is how a "clean" test ends up crashing on missing
         # content instead of on the thing being tested.
-        data_path = os.path.join(STEAM_COMMON, state["install_dir"], "Data")
+        data_path = os.path.join(
+            _game_paths(state["install_dir"], "")[0], "Data"
+        )
         _rewrite_load_order(
             data_path, path, state["plugins_style"],
             IMPLICIT_MASTERS_BY_DOMAIN.get(state["game_domain"], frozenset()),
@@ -20144,7 +20146,9 @@ query CollectionInstructions($slug: String!) {
         state = _bisect_advance(state, bool(crashed))
         collateral = []
         if state.get("found"):
-            data_path = os.path.join(STEAM_COMMON, state["install_dir"], "Data")
+            data_path = os.path.join(
+            _game_paths(state["install_dir"], "")[0], "Data"
+        )
             collateral = await asyncio.to_thread(
                 _dependents_closure, data_path, state["order"],
                 set(state["skipped"]),
@@ -20179,7 +20183,9 @@ query CollectionInstructions($slug: String!) {
         _write_plugins_txt(path, header + [
             ("*" + n if n.lower() in on else n) for n, _ in entries
         ])
-        data_path = os.path.join(STEAM_COMMON, state["install_dir"], "Data")
+        data_path = os.path.join(
+            _game_paths(state["install_dir"], "")[0], "Data"
+        )
         _rewrite_load_order(
             data_path, path, state["plugins_style"],
             IMPLICIT_MASTERS_BY_DOMAIN.get(state["game_domain"], frozenset()),
@@ -20560,7 +20566,7 @@ query CollectionInstructions($slug: String!) {
         scan(disabled_path, False)
         # Mods routed to alternate targets (UE4SS dirs, LogicMods) don't
         # live in the scanned dirs - list them from their records.
-        install_path = os.path.join(STEAM_COMMON, install_dir)
+        install_path = _game_paths(install_dir, "")[0]
         for key, rec in records.items():
             target = rec.get("target")
             if not target:
@@ -20824,7 +20830,7 @@ query CollectionInstructions($slug: String!) {
             settings = _load_settings()
             records = settings.get("installed", {}).get(game_domain, {})
             rec = records.get(folder) or rec
-            install_path = os.path.join(STEAM_COMMON, install_dir)
+            install_path = _game_paths(install_dir, "")[0]
             park = _parked_files_dir(game_domain, folder)
             shared = _shared_paths(records, folder, modes=("files",))
             movable = [
@@ -20853,7 +20859,7 @@ query CollectionInstructions($slug: String!) {
             )
             return {"ok": True, "moved": moved, "shared": len(shared)}
         if rec and rec.get("target"):
-            install_path = os.path.join(STEAM_COMMON, install_dir)
+            install_path = _game_paths(install_dir, "")[0]
             base = os.path.join(install_path, *rec["target"].split("/"))
             real = rec.get("folder") or folder
             if rec["target"] == "dlc" and _w3_official_dlc(real):
@@ -21073,7 +21079,7 @@ query CollectionInstructions($slug: String!) {
         settings = _load_settings()
         rec = settings.get("installed", {}).get(game_domain, {}).get(folder)
         if rec and rec.get("target"):
-            install_path = os.path.join(STEAM_COMMON, install_dir)
+            install_path = _game_paths(install_dir, "")[0]
             base = os.path.join(install_path, *rec["target"].split("/"))
             if rec.get("mode") == "files":
                 for name in rec.get("files") or []:
@@ -21125,12 +21131,12 @@ query CollectionInstructions($slug: String!) {
         # A merge participant leaving: recompute its merged scripts from
         # the remaining participants.
         _w3_unmerge(
-            game_domain, os.path.join(STEAM_COMMON, install_dir),
+            game_domain, _game_paths(install_dir, "")[0],
             mods_path, folder, settings,
         )
         _save_settings(settings)
         if dropped:
-            install_root = os.path.join(STEAM_COMMON, install_dir)
+            install_root = _game_paths(install_dir, "")[0]
             _w3_remove_menu_xmls(install_root, dropped)
             pc_dir = os.path.join(install_root, *W3_MENU_DIR.split("/"))
             if os.path.isdir(pc_dir):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -18552,5 +18552,55 @@ class TestBg3BootHunt(unittest.TestCase):
         self.assertIn("Data", seg)
 
 
+class TestGamesOutsideTheMainLibrary(unittest.TestCase):
+    """A game on an SD card lives in a different steamapps directory.
+
+    _game_paths has known that from the start; twenty-four other call sites
+    did not, and built the game folder straight from STEAM_COMMON. The
+    visible symptom was Step 1: install_framework recorded the vanilla
+    baseline against the RIGHT path, then _install_framework_inner
+    recomputed the wrong one and returned "Game install folder not found" -
+    with no log line, so the log showed a baseline and then silence.
+
+    Found on a Steam Deck whose Shadow of War sits on the SD card, but it
+    was never about one game: every game outside the main library was
+    affected, on every one of those paths.
+    """
+
+    def test_the_resolver_finds_a_game_in_a_second_library(self):
+        sd = os.path.join(TEST_ROOT, "sdcard", "steamapps")
+        os.makedirs(os.path.join(sd, "common", "ShadowOfWar", "x64"), exist_ok=True)
+        with mock.patch.object(main, "_steam_libraries", return_value=[sd]):
+            install_path, mods_path, _d = main._game_paths(
+                "ShadowOfWar", "x64/plugins"
+            )
+        self.assertEqual(
+            install_path, os.path.join(sd, "common", "ShadowOfWar")
+        )
+        self.assertTrue(mods_path.endswith(os.path.join("x64", "plugins")))
+
+    def test_only_the_resolver_itself_builds_a_game_path_from_steam_common(self):
+        with open(main.__file__, encoding="utf-8") as fh:
+            lines = fh.readlines()
+        # A game folder is STEAM_COMMON joined with an install dir. Every
+        # one of those has to go through _game_paths instead - except the
+        # single fallback inside _game_paths itself.
+        offenders = [
+            (n, line.strip())
+            for n, line in enumerate(lines, 1)
+            if "STEAM_COMMON" in line
+            and ("install_dir" in line or 'state["install_dir"]' in line)
+        ]
+        self.assertEqual(
+            len(offenders), 1,
+            f"game paths built from STEAM_COMMON directly: {offenders}",
+        )
+        # And that one is the fallback, inside _game_paths.
+        line_no = offenders[0][0]
+        preceding = "".join(lines[max(0, line_no - 6):line_no])
+        self.assertIn("def _game_paths", preceding)
+
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -18579,7 +18579,7 @@ class TestGamesOutsideTheMainLibrary(unittest.TestCase):
         )
         self.assertTrue(mods_path.endswith(os.path.join("x64", "plugins")))
 
-    RESOLVERS = {"_steam_libraries", "_game_paths", "_prefix_drive_c"}
+    RESOLVERS = {"_steam_libraries", "_game_dir", "_prefix_drive_c"}
 
     def test_only_the_resolvers_may_name_steam_common(self):
         """STEAM_COMMON is the MAIN library. Naming it anywhere else is the

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -18579,26 +18579,71 @@ class TestGamesOutsideTheMainLibrary(unittest.TestCase):
         )
         self.assertTrue(mods_path.endswith(os.path.join("x64", "plugins")))
 
-    def test_only_the_resolver_itself_builds_a_game_path_from_steam_common(self):
+    RESOLVERS = {"_steam_libraries", "_game_paths", "_prefix_drive_c"}
+
+    def test_only_the_resolvers_may_name_steam_common(self):
+        """STEAM_COMMON is the MAIN library. Naming it anywhere else is the
+        bug, whatever the expression around it looks like.
+
+        The first version of this test matched on the spelling instead:
+        STEAM_COMMON on the same line as install_dir. It passed while
+        get_me3_state was still listing Proton builds out of
+        os.listdir(STEAM_COMMON) three lines from a shape it did match - a
+        guard that certified the file clean with an instance still in it.
+        So this one asks where the name is USED, not how.
+        """
         with open(main.__file__, encoding="utf-8") as fh:
-            lines = fh.readlines()
-        # A game folder is STEAM_COMMON joined with an install dir. Every
-        # one of those has to go through _game_paths instead - except the
-        # single fallback inside _game_paths itself.
-        offenders = [
-            (n, line.strip())
-            for n, line in enumerate(lines, 1)
-            if "STEAM_COMMON" in line
-            and ("install_dir" in line or 'state["install_dir"]' in line)
-        ]
+            tree = ast.parse(fh.read())
+        parents = {}
+        for node in ast.walk(tree):
+            for child in ast.iter_child_nodes(node):
+                parents[child] = node
+
+        def enclosing_function(node):
+            cur = parents.get(node)
+            while cur is not None:
+                if isinstance(cur, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    return cur.name
+                cur = parents.get(cur)
+            return None  # module level: the definition itself
+
+        offenders = sorted({
+            enclosing_function(node)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Name) and node.id == "STEAM_COMMON"
+            and enclosing_function(node) is not None
+            and enclosing_function(node) not in self.RESOLVERS
+        })
         self.assertEqual(
-            len(offenders), 1,
-            f"game paths built from STEAM_COMMON directly: {offenders}",
+            offenders, [],
+            "these reach for the main library directly instead of asking "
+            f"the resolvers: {offenders}",
         )
-        # And that one is the fallback, inside _game_paths.
-        line_no = offenders[0][0]
-        preceding = "".join(lines[max(0, line_no - 6):line_no])
-        self.assertIn("def _game_paths", preceding)
+
+    def test_proton_builds_are_found_in_every_library(self):
+        # The instance the first guard could not see: me3 needs a Proton,
+        # and a Deck with its games on the card has its Protons there too.
+        sd = os.path.join(TEST_ROOT, "proton-sd", "steamapps")
+        os.makedirs(os.path.join(sd, "common", "Proton 9.0"), exist_ok=True)
+        main_lib = os.path.join(TEST_ROOT, "proton-main", "steamapps")
+        os.makedirs(os.path.join(main_lib, "common", "Proton 8.0"), exist_ok=True)
+        # A file, not a directory, and a non-Proton folder: neither counts.
+        open(os.path.join(sd, "common", "protonmail.txt"), "w").close()
+        os.makedirs(os.path.join(sd, "common", "SomeGame"), exist_ok=True)
+        with mock.patch.object(
+            main, "_steam_libraries", return_value=[main_lib, sd]
+        ):
+            self.assertEqual(
+                main._proton_builds(), ["Proton 8.0", "Proton 9.0"]
+            )
+
+    def test_a_build_present_in_two_libraries_is_one_choice(self):
+        a = os.path.join(TEST_ROOT, "proton-dup-a", "steamapps")
+        b = os.path.join(TEST_ROOT, "proton-dup-b", "steamapps")
+        for lib in (a, b):
+            os.makedirs(os.path.join(lib, "common", "Proton 9.0"), exist_ok=True)
+        with mock.patch.object(main, "_steam_libraries", return_value=[a, b]):
+            self.assertEqual(main._proton_builds(), ["Proton 9.0"])
 
 
 


### PR DESCRIPTION
`_game_paths` has always searched every Steam library and fallen back to the main one. Twenty-five other call sites did not: they build the game folder as `STEAM_COMMON + install_dir`, which for a game on an SD card or a second drive is a path that does not exist.

### The symptom

Step 1, on a Steam Deck whose game is on the SD card. `install_framework` records the vanilla baseline against the **right** path, then `_install_framework_inner` recomputes the wrong one and returns `"Game install folder not found"` — a string with no log line behind it, so the log shows a baseline written and then nothing at all:

```
[INFO]: game status for 'ShadowOfWar': {'installed': True, 'install_path': '/run/media/deck/SD_MMC CRW/steamapps/common/ShadowOfWar', ...}
[INFO]: middleearthshadowofwar: recorded a 0-entry vanilla baseline for the mods folder
                                        <- nothing further
```

The panel finds the game (that path comes from `get_game_status`, which uses `_game_paths`), so from the user's side the plugin knows exactly where the game is and then says it cannot find it.

`uninstall_mod`, `set_mod_enabled`, `scan`, `get_load_order_state`, the crash-bisect helpers and the script-extender plugin paths have it too — so a mod that did install could not be removed again.

### The change

Every one of those now goes through `_game_paths(install_dir, "")[0]`. For a game in the main library the result is **identical**, because that is `_game_paths`' own fallback — so this is a no-op for anyone it was already working for.

`_prefix_drive_c` already got this right for compatdata ("compatdata sits in whichever library holds the game"), which is what suggested the same was true of the game folder itself.

### The test

`TestGamesOutsideTheMainLibrary` does two things: resolves a game in a mocked second library, and fails if a game path is ever built from `STEAM_COMMON` again outside the resolver. The second one is the one that matters — this is the kind of line that gets written again by hand.

### What I verified

- `python -m unittest discover -s tests` — 1258 pass, 1 skipped
- `tsc --noEmit --skipLibCheck` — clean
- On device (SteamOS, Decky v3.2.8): the failing case above is a Shadow of War install on the SD card

Found while adding a game, but it is not about that game and nothing game-specific is in this branch. The internal drive is 64GB on the model that has one, so most Deck libraries end up on a card.