### PR TITLE
Add Starfield support (SFSE framework, verified on device)

### DIFF
--- a/main.py
+++ b/main.py
@@ -1717,6 +1717,12 @@ DATA_MARKER_DIRS = {
     "distributedmods", "netscriptframework", "dialogueviews", "lodsettings",
     "planetdata", "calientetools", "tools", "source", "facegendata",
     "actors", "effects", "misc", "dyndolod",
+    # Starfield (2026-09-08): Address Library for SFSE Plugins ships
+    # SFSE/Plugins/<file> at the archive root, same shape as SKSE/F4SE/NVSE
+    # plugin archives - failed with "no recognizable Data payload" until
+    # "sfse" joined its siblings here (Matt, on device: "I'm getting errors
+    # trying to install the Address Library for SFSE Plugins").
+    "sfse",
 }
 
 # Junk some archives carry that must never reach the game folder: macOS

--- a/src/games.ts
+++ b/src/games.ts
@@ -1203,6 +1203,71 @@ export const SUPPORTED_GAMES: Record<number, SupportedGame> = {
       installKind: "copyRoot",
     },
   },
+  1716740: {
+    appId: 1716740,
+    displayName: "Starfield",
+    // TODO verify: Nexus's domain slug for this game.
+    nexusDomain: "starfield",
+    // TODO verify on device: Steam library folder name.
+    installDirName: "Starfield",
+    modsSubdir: "Data",
+    installMode: "dataDir",
+    // Bethesda-standard layout, same as SSE/FO4 - TODO verify Starfield
+    // actually writes Plugins.txt here without extra config. Community
+    // history on this game is that plugin activation sometimes needs an
+    // ini-based workaround (StarfieldCustom.ini file-selection entries)
+    // rather than reading Plugins.txt directly like SSE/FO4 do; this has
+    // not been confirmed on this device and may need a follow-up fix.
+    pluginsTxtSubpath: "Starfield/Plugins.txt",
+    pluginsTxtStyle: "starred",
+    moddedSaveWarning: false,
+    // TODO verify comm name under Proton.
+    processName: "Starfield.exe",
+    // Every other Bethesda-Steam game on this list needed this (ancient
+    // CRT left by Steam's install script breaks dynamically-linked script
+    // extender plugins) - carried over on the same assumption, unverified
+    // for Starfield specifically.
+    prefixRuntimeFix: true,
+    framework: {
+      name: "SFSE",
+      // TODO verify: assumes the same "<prefix>_loader.exe" naming SKSE64/
+      // F4SE/xNVSE use (all from the same silverlock.org author).
+      detectFile: "sfse_loader.exe",
+      url: "sfse.silverlock.org",
+      // Deliberately omitted: shipping a guessed Nexus mod id risks
+      // routing the one-tap install at the wrong file. Leaving this unset
+      // disables just that button (see index.tsx's
+      // `disabled={... || !game.framework.nexusModId}`) instead of
+      // silently downloading something wrong - fill in once looked up on
+      // nexusmods.com/starfield.
+      installKind: "copyRoot",
+      // TODO verify: assumes Steam launches Starfield.exe directly (no
+      // separate *Launcher.exe the way SSE/FO4 have) so the loader swap
+      // targets the game exe itself.
+      launchOptionsTemplate:
+        "bash -c 'exec \"$" +
+        "{@/Starfield.exe/sfse_loader.exe}\"' -- %command%",
+      // TODO verify: files SFSE actually leaves in the game root.
+      cleanupPrefixes: ["sfse"],
+    },
+    // TODO verify: Starfield shares FO4's engine lineage, so loose files
+    // are assumed to need the same archive-invalidation block - unconfirmed
+    // for this game.
+    setupInis: [
+      {
+        prefsSubpath: "Starfield/StarfieldCustom.ini",
+        section: "Archive",
+        settings: {
+          bInvalidateOlderFiles: "1",
+          sResourceDataDirsFinal: "",
+        },
+      },
+    ],
+    underConstruction:
+      "Starfield support is untested on real hardware - every path and " +
+      "filename above is a best guess from the SSE/FO4 pattern, not a " +
+      "verified fact. Expect breakage until this has been run on device.",
+  },
 };
 
 /** Positional params several backend calls need for install-mode dispatch. */

--- a/src/games.ts
+++ b/src/games.ts
@@ -1206,10 +1206,13 @@ export const SUPPORTED_GAMES: Record<number, SupportedGame> = {
   1716740: {
     appId: 1716740,
     displayName: "Starfield",
-    // TODO verify: Nexus's domain slug for this game.
+    // Verified on device: get_mods('starfield', ...) returned real results
+    // (12130 mods) and install_mod resolved SFSE's real page on it.
     nexusDomain: "starfield",
-    // TODO verify on device: Steam library folder name.
+    // Verified on device 2026-09-08 (game status log): install path really
+    // is steamapps/common/Starfield.
     installDirName: "Starfield",
+    // Verified on device: game status logged mods_dir_exists=True here.
     modsSubdir: "Data",
     installMode: "dataDir",
     // Bethesda-standard layout, same as SSE/FO4 - TODO verify Starfield
@@ -1221,7 +1224,8 @@ export const SUPPORTED_GAMES: Record<number, SupportedGame> = {
     pluginsTxtSubpath: "Starfield/Plugins.txt",
     pluginsTxtStyle: "starred",
     moddedSaveWarning: false,
-    // TODO verify comm name under Proton.
+    // Verified on device: `ps -o comm` on the running game reported exactly
+    // "Starfield.exe", untruncated.
     processName: "Starfield.exe",
     // Every other Bethesda-Steam game on this list needed this (ancient
     // CRT left by Steam's install script breaks dynamically-linked script
@@ -1230,9 +1234,11 @@ export const SUPPORTED_GAMES: Record<number, SupportedGame> = {
     prefixRuntimeFix: true,
     framework: {
       name: "SFSE",
-      // TODO verify: assumes the same "<prefix>_loader.exe" naming SKSE64/
-      // F4SE/xNVSE use (all from the same silverlock.org author) - the
-      // filename itself isn't confirmed yet, only the mod id is.
+      // Verified on device: this is really what SFSE's archive ships
+      // ("<prefix>_loader.exe", same as SKSE64/F4SE/xNVSE, all from the
+      // same silverlock.org author) - `ps aux` showed Steam launching it
+      // (AppId=1716740 -- .../sfse_loader.exe) and SFSE's own "Address
+      // Library" dialog came up, proving it actually ran under Proton.
       detectFile: "sfse_loader.exe",
       url: "sfse.silverlock.org",
       // Verified on device 2026-09-08: install_mod's own log line for a
@@ -1250,14 +1256,25 @@ export const SUPPORTED_GAMES: Record<number, SupportedGame> = {
       // known rather than guessed.
       nexusModId: 106,
       installKind: "copyRoot",
-      // TODO verify: assumes Steam launches Starfield.exe directly (no
-      // separate *Launcher.exe the way SSE/FO4 have) so the loader swap
-      // targets the game exe itself.
+      // Verified on device: Starfield has no separate *Launcher.exe the way
+      // SSE/FO4 do, so the swap targets the game exe directly - confirmed
+      // by `ps aux`, which showed Proton launching sfse_loader.exe for
+      // AppId 1716740 instead of Starfield.exe, and the game itself came up
+      // (Starfield.exe running as a child process) with SFSE's dialog on
+      // top of it.
       launchOptionsTemplate:
         "bash -c 'exec \"$" +
         "{@/Starfield.exe/sfse_loader.exe}\"' -- %command%",
-      // TODO verify: files SFSE actually leaves in the game root.
-      cleanupPrefixes: ["sfse"],
+      // Verified on device: SFSE's archive drops sfse_loader.exe,
+      // sfse_1_16_244.dll, sfse_readme.txt and sfse_whatsnew.txt at the
+      // game root (all "sfse"-prefixed, covered by the bare prefix below)
+      // plus Data/SFSE (its plugins folder, listed explicitly the same way
+      // New Vegas lists Data/NVSE - a bare "sfse" prefix is top-level-only
+      // and would never reach it). It also drops a top-level src/ folder
+      // holding its own source tarball; left uncleaned deliberately - "src"
+      // is too generic a prefix to trust broadly, and stray source tarballs
+      // left behind by a reset are clutter, not a functional problem.
+      cleanupPrefixes: ["sfse", "Data/SFSE"],
     },
     // TODO verify: Starfield shares FO4's engine lineage, so loose files
     // are assumed to need the same archive-invalidation block - unconfirmed
@@ -1273,9 +1290,12 @@ export const SUPPORTED_GAMES: Record<number, SupportedGame> = {
       },
     ],
     underConstruction:
-      "Starfield support is untested on real hardware - every path and " +
-      "filename above is a best guess from the SSE/FO4 pattern, not a " +
-      "verified fact. Expect breakage until this has been run on device.",
+      "Starfield support is new: Step 1 (installing SFSE) is verified " +
+      "working on device, including the launch swap to sfse_loader.exe. " +
+      "Not yet confirmed: whether ordinary Data mods actually get picked " +
+      "up via Plugins.txt, and whether the archive-invalidation ini and " +
+      "runtime-repair steps are needed here the way they are on SSE/FO4. " +
+      "Expect rough edges past Step 1.",
   },
 };
 

--- a/src/games.ts
+++ b/src/games.ts
@@ -1231,15 +1231,24 @@ export const SUPPORTED_GAMES: Record<number, SupportedGame> = {
     framework: {
       name: "SFSE",
       // TODO verify: assumes the same "<prefix>_loader.exe" naming SKSE64/
-      // F4SE/xNVSE use (all from the same silverlock.org author).
+      // F4SE/xNVSE use (all from the same silverlock.org author) - the
+      // filename itself isn't confirmed yet, only the mod id is.
       detectFile: "sfse_loader.exe",
       url: "sfse.silverlock.org",
-      // Deliberately omitted: shipping a guessed Nexus mod id risks
-      // routing the one-tap install at the wrong file. Leaving this unset
-      // disables just that button (see index.tsx's
-      // `disabled={... || !game.framework.nexusModId}`) instead of
-      // silently downloading something wrong - fill in once looked up on
-      // nexusmods.com/starfield.
+      // Verified on device 2026-09-08: install_mod's own log line for a
+      // real Nexus download - "starfield/106 file 67782 ('Starfield
+      // Script Extender (SFSE)' v'0.2.21')" - straight from trying to
+      // install SFSE off its mod page before this was set (Matt: "the
+      // button cannot be clicked... If I try to install SFSE from the
+      // mod list, it errors out"). That attempt failed correctly - a
+      // bare loader.exe archive routes through install_mod's generic
+      // Data-folder installer and gets refused as a "PC modding tool",
+      // same as SKSE64/F4SE would if installed that way. Framework
+      // installs are supposed to go through install_framework's copyRoot
+      // path instead (the Step 1 button), which nexusModId is what
+      // enables - it was left blank on purpose until the real id was
+      // known rather than guessed.
+      nexusModId: 106,
       installKind: "copyRoot",
       // TODO verify: assumes Steam launches Starfield.exe directly (no
       // separate *Launcher.exe the way SSE/FO4 have) so the loader swap

--- a/tests/game-config.snapshot.json
+++ b/tests/game-config.snapshot.json
@@ -349,7 +349,7 @@
     "hasOwnLauncher": false,
     "longWaitAtMods": null,
     "cleanupPrefixes": [
-      "\"sfse\""
+      "\"sfse\", \"Data/SFSE\""
     ]
   },
   {

--- a/tests/game-config.snapshot.json
+++ b/tests/game-config.snapshot.json
@@ -339,7 +339,9 @@
     "installMode": "dataDir",
     "frameworkName": "SFSE",
     "launchOptionsTemplate": "bash -c 'exec \"${@/Starfield.exe/sfse_loader.exe}\"' -- %command%",
-    "prefixTools": [],
+    "prefixTools": [
+      "106"
+    ],
     "manualTools": 0,
     "hasLauncherBypass": false,
     "hasSetupInis": true,

--- a/tests/game-config.snapshot.json
+++ b/tests/game-config.snapshot.json
@@ -329,6 +329,28 @@
     ]
   },
   {
+    "appId": "1716740",
+    "displayName": "Starfield",
+    "nexusDomain": "starfield",
+    "installDirName": "Starfield",
+    "modsSubdir": "Data",
+    "pluginsTxtSubpath": "Starfield/Plugins.txt",
+    "pluginsTxtStyle": "starred",
+    "installMode": "dataDir",
+    "frameworkName": "SFSE",
+    "launchOptionsTemplate": "bash -c 'exec \"${@/Starfield.exe/sfse_loader.exe}\"' -- %command%",
+    "prefixTools": [],
+    "manualTools": 0,
+    "hasLauncherBypass": false,
+    "hasSetupInis": true,
+    "hasLogAdapter": false,
+    "hasOwnLauncher": false,
+    "longWaitAtMods": null,
+    "cleanupPrefixes": [
+      "\"sfse\""
+    ]
+  },
+  {
     "appId": "2050650",
     "displayName": "Resident Evil 4",
     "nexusDomain": "residentevil42023",


### PR DESCRIPTION
## Summary
- Adds Starfield support (SFSE framework, dataDir mods) alongside the other Bethesda Creation Engine games (Skyrim SE, Fallout 4, New Vegas, Fallout 3)
- Verified on a real Steam Deck: Step 1 installs SFSE via the copyRoot path and the launch-option swap actually boots the game through `sfse_loader.exe` instead of `Starfield.exe` - confirmed via `ps aux` and SFSE's own first-run "Address Library" dialog appearing
- Fixed a shared classifier gap found along the way: `DATA_MARKER_DIRS` (main.py) didn't recognize `sfse` as a script-extender plugin folder, so any SFSE-plugin archive (e.g. "Address Library for SFSE Plugins") was refused as "no recognizable Data payload" - same fix class as the existing skse/f4se/nvse entries, and not specific to Starfield's game config

## Verified on device
- Install dir (`Starfield`), mods dir (`Data`), process name (`Starfield.exe`, exact `comm` match, no truncation), SFSE's real Nexus mod id (106), detect file (`sfse_loader.exe`), and the launcher-swap launch option
- SFSE plugin archives (Address Library for SFSE Plugins) install correctly after the `DATA_MARKER_DIRS` fix
- `Data/SFSE` added to the framework's `cleanupPrefixes` (a bare `sfse` prefix is top-level-only and never reached it) - same class of gap as New Vegas's `Data/NVSE`

## Not yet verified
- Whether ordinary Data-folder mods actually get picked up via `Plugins.txt` the way SSE/FO4 do, or whether Starfield needs an ini-based workaround instead
- Whether the archive-invalidation ini block and the VC++ runtime repair step are actually needed on this game
- The `underConstruction` banner is left in place on purpose until those are confirmed

## Test plan
- [x] `pnpm run typecheck` and `pnpm run build`
- [x] `pnpm run test:games` (snapshot) plus the nav/proton/panel/compat JS suites
- [x] `python -m unittest discover -s tests` (1282 tests)
- [x] Installed SFSE via Step 1 on device and confirmed the game launches through it
- [x] Installed a real SFSE-plugin mod (Address Library) after the `DATA_MARKER_DIRS` fix
